### PR TITLE
Support routes over construction railways

### DIFF
--- a/functions/getData.php
+++ b/functions/getData.php
@@ -759,7 +759,14 @@ Class Route
 			}
 				
 			// check if way is railway
-			if ( !isset($this->way_tags[$b]["railway"]) || ( $this->way_tags[$b]["railway"] != "rail" && $this->way_tags[$b]["railway"] != "light_rail" && $this->way_tags[$b]["railway"] != "tram" && $this->way_tags[$b]["railway"] != "narrow_gauge") && $this->way_tags[$b]["railway"] != "miniature" && $this->way_tags[$b]["railway"] != "subway" )
+			if ( !isset($this->way_tags[$b]["railway"]) ||
+				( $this->way_tags[$b]["railway"] != "rail" &&
+				$this->way_tags[$b]["railway"] != "light_rail" &&
+				$this->way_tags[$b]["railway"] != "tram" &&
+				$this->way_tags[$b]["railway"] != "narrow_gauge") &&
+				$this->way_tags[$b]["railway"] != "miniature" &&
+				$this->way_tags[$b]["railway"] != "subway" &&
+				$this->way_tags[$b]["railway"] != "construction")
 			{
 				continue;
 			}


### PR DESCRIPTION
Sometimes railways are under construction, nevertheless a route is set over it.

That should be ignored, as it is unlogic to have a route over a railway being in construction.

Nevertheless that should not be a problem for the tool. Ignoring it will leed to strange results (no warning, the route is shorter than in reality, the signals on the construction track are not shown).

If some way without the allowed types is found that should throw a warning in form of a gap.