### PR TITLE
query all stop area relations the stops of the current route belong to

### DIFF
--- a/functions/getData.php
+++ b/functions/getData.php
@@ -412,9 +412,15 @@ Class Route
 			if ( $refresh )
 			{
 				// build link to overpass api
-				$overpass_query = "[out:xml];(relation("
-					. $get_id
-					. ");rel(br)->.mr;>>;);out;";
+				$overpass_query = '[out:xml];' .
+						/* query the base relation into "r" */
+						'relation(' . $get_id . ')->.r;' .
+						/* print "r" all it's members */
+						'.r >>;out;' .
+						/* print all relations "r" is member in, usually the route_master */
+						'rel(br.r);out;' .
+						/* for all nodes in "r" with role stop query the PT=stop_area relations they are member in */
+						'node(r.r:"stop");rel(bn:"stop")["type"="public_transport"]["public_transport"="stop_area"];out;';
 				if( Overpass::sendRequest($overpass_query) )
 				{
 					$this->refresh_success = true;

--- a/functions/getData.php
+++ b/functions/getData.php
@@ -619,12 +619,12 @@ Class Route
 			}
 			
 			
-			// only ways of relation with the loaded id is needed - this is needed only once (sometimes relations are more than once in the data)
+			// only ways of relation with the loaded id are needed - this is needed only once (sometimes relations are more than once in the data)
 			if ( $rel_id != $this->id || $rel_done )
 			{
 				continue;
 			}
-			$rel_done = true; // relation was parsed already -> dos not need to be parsed again.
+			$rel_done = true; // relation was parsed already -> does not need to be parsed again.
 			
 			//load relation members
 			foreach ( $relation->member as $member ) 

--- a/functions/getData.php
+++ b/functions/getData.php
@@ -414,9 +414,7 @@ Class Route
 				// build link to overpass api
 				$overpass_query = "[out:xml];(relation("
 					. $get_id
-					. ");rel(br););out;(relation("
-					. $get_id
-					. ");>>;);out;";
+					. ");rel(br)->.mr;>>;);out;";
 				if( Overpass::sendRequest($overpass_query) )
 				{
 					$this->refresh_success = true;


### PR DESCRIPTION
This fixes the query-part of #2. The data is not processed yet.

Please merge #108 first.